### PR TITLE
Move PyCall and Test to test dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,4 @@ version = "0.1.0"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 c_questdb_client_jll = "49a0df60-3d80-5428-85ce-5c0f24fd7b67"

--- a/src/QuestDB.jl
+++ b/src/QuestDB.jl
@@ -71,7 +71,7 @@ mutable struct Sender
     sender::Ref{line_sender}
     auth::Bool
     
-    function Sender(host::String="localhost", port::Int=9009; auth=nothing, tls::Bool=false)
+    function Sender(host::String="localhost", port::Int=9009; auth=nothing, tls::Bool=false, init_capacity::Int=128*1024)
         err = Ref{Ptr{line_sender_error}}(C_NULL)
         opts = Ref{line_sender_opts}()
         sender = Ref{line_sender}()
@@ -83,7 +83,7 @@ mutable struct Sender
         pub_key_x_utf8 = Ref{line_sender_utf8}()
         pub_key_y_utf8 = Ref{line_sender_utf8}()
 
-        is_host_ok = line_sender_utf8_init(host_utf8, length(host), host, err)    
+        is_host_ok = line_sender_utf8_init(host_utf8, length(host), host, err)
 
         global buffer = line_sender_buffer_new();
         line_sender_buffer_reserve(buffer, 64 * 1024);        
@@ -107,10 +107,10 @@ mutable struct Sender
             global sender = line_sender_connect(opts, err)                                                    
             line_sender_opts_free(opts)        
             
-            if (sender == C_NULL)                                
+            if (sender == C_NULL)                        
                 return error_handler(sender, buffer, err);           
             end            
-        else            
+        else         
             error_handler(sender, buffer, err);           
         end;
                     

--- a/src/QuestDB.jl
+++ b/src/QuestDB.jl
@@ -65,18 +65,18 @@ mutable struct Sender
     priv_key_utf8::Ref{line_sender_utf8}
     pub_key_x_utf8::Ref{line_sender_utf8}
     pub_key_y_utf8::Ref{line_sender_utf8}
-    buffer::Ref{line_sender_buffer}
+    buffer::Ptr{line_sender_buffer}
     opts::Ref{line_sender_opts}
     err::Ref{Ptr{line_sender_error}}
-    sender::Ref{line_sender}
+    sender::Ptr{line_sender}
     auth::Bool
 
     function Sender(host::String="localhost", port::Int=9009; auth=nothing, tls::Bool=false, init_capacity::Int=128 * 1024)
         err = Ref{Ptr{line_sender_error}}(C_NULL)
         opts = Ref{line_sender_opts}()
-        sender = Ref{line_sender}()
+        sender = C_NULL
         port = Ref{UInt16}(port)
-        buffer = Ref{line_sender_buffer}()
+        buffer = C_NULL
         host_utf8 = Ref{line_sender_utf8}()
         key_id_utf8 = Ref{line_sender_utf8}()
         priv_key_utf8 = Ref{line_sender_utf8}()
@@ -85,8 +85,8 @@ mutable struct Sender
 
         is_host_ok = line_sender_utf8_init(host_utf8, length(host), host, err)
 
-        buffer[] = line_sender_buffer_new()
-        line_sender_buffer_reserve(buffer[], init_capacity)
+        buffer = line_sender_buffer_new()
+        line_sender_buffer_reserve(buffer, init_capacity)
 
         if (is_host_ok)
             opts = line_sender_opts_new(host_utf8[], port[])
@@ -104,7 +104,7 @@ mutable struct Sender
                 line_sender_opts_auth(opts, key_id_utf8[], priv_key_utf8[], pub_key_x_utf8[], pub_key_y_utf8[])
             end
 
-            global sender = line_sender_connect(opts, err)
+            sender = line_sender_connect(opts, err)
             line_sender_opts_free(opts)
 
             if (sender == C_NULL)
@@ -118,11 +118,11 @@ mutable struct Sender
 
         # Register finalizer to clean up C resources
         finalizer(s) do sender_obj
-            if sender_obj.buffer[] != C_NULL
-                line_sender_buffer_free(sender_obj.buffer[])
+            if sender_obj.buffer != C_NULL
+                line_sender_buffer_free(sender_obj.buffer)
             end
-            if sender_obj.sender[] != C_NULL
-                line_sender_close(sender_obj.sender[])
+            if sender_obj.sender != C_NULL
+                line_sender_close(sender_obj.sender)
             end
         end
 
@@ -150,7 +150,7 @@ function Base.getproperty(s::Sender, f::Base.Symbol)
     return getfield(s, f)
 end
 
-function error_handler(sender::Ref{line_sender}, buffer::Ptr{line_sender_buffer}, err::Ref{Ptr{line_sender_error}})
+function error_handler(sender::Ptr{line_sender}, buffer::Ptr{line_sender_buffer}, err::Ref{Ptr{line_sender_error}})
     code = line_sender_error_get_code(err[])
     len = Ref{Csize_t}(100)
     message = line_sender_error_msg(err[], len)
@@ -378,15 +378,15 @@ function (close::Close)()
     sender = close.sender
 
     # Free buffer if not already freed
-    if sender.buffer[] != C_NULL
-        line_sender_buffer_free(sender.buffer[])
-        sender.buffer[] = C_NULL
+    if sender.buffer != C_NULL
+        line_sender_buffer_free(sender.buffer)
+        sender.buffer = C_NULL
     end
 
     # Close sender connection
-    if sender.sender[] != C_NULL
-        line_sender_close(sender.sender[])
-        sender.sender[] = C_NULL
+    if sender.sender != C_NULL
+        line_sender_close(sender.sender)
+        sender.sender = C_NULL
     end
 end
 

--- a/src/QuestDB.jl
+++ b/src/QuestDB.jl
@@ -177,8 +177,12 @@ function error_handler(sender::Ptr{line_sender}, buffer::Ptr{line_sender_buffer}
     end
 
     line_sender_error_free(err[])
-    line_sender_buffer_free(buffer)
-    line_sender_close(sender)
+    if buffer != C_NULL
+        line_sender_buffer_free(buffer)
+    end
+    if sender != C_NULL
+        line_sender_close(sender)
+    end
     throw(ErrorException(error_message))
 end
 

--- a/src/QuestDB.jl
+++ b/src/QuestDB.jl
@@ -120,9 +120,11 @@ mutable struct Sender
         finalizer(s) do sender_obj
             if sender_obj.buffer != C_NULL
                 line_sender_buffer_free(sender_obj.buffer)
+                sender_obj.buffer = C_NULL
             end
             if sender_obj.sender != C_NULL
                 line_sender_close(sender_obj.sender)
+                sender_obj.sender = C_NULL
             end
         end
 

--- a/src/QuestDB.jl
+++ b/src/QuestDB.jl
@@ -3,7 +3,7 @@ module QuestDB
 
 include("LibQuestDB.jl")
 
-using .LibQuestDB 
+using .LibQuestDB
 using Dates
 
 struct Table{T}
@@ -58,7 +58,7 @@ end
     ## Returns        
     Sender object that can be used to send data.
 """
-mutable struct Sender        
+mutable struct Sender
     host_utf8::Ref{line_sender_utf8}
     port::Ref{UInt16}
     key_id_utf8::Ref{line_sender_utf8}
@@ -66,18 +66,18 @@ mutable struct Sender
     pub_key_x_utf8::Ref{line_sender_utf8}
     pub_key_y_utf8::Ref{line_sender_utf8}
     buffer::Ref{line_sender_buffer}
-    opts::Ref{line_sender_opts}    
-    err::Ref{Ptr{line_sender_error}}    
+    opts::Ref{line_sender_opts}
+    err::Ref{Ptr{line_sender_error}}
     sender::Ref{line_sender}
     auth::Bool
-    
-    function Sender(host::String="localhost", port::Int=9009; auth=nothing, tls::Bool=false, init_capacity::Int=128*1024)
+
+    function Sender(host::String="localhost", port::Int=9009; auth=nothing, tls::Bool=false, init_capacity::Int=128 * 1024)
         err = Ref{Ptr{line_sender_error}}(C_NULL)
         opts = Ref{line_sender_opts}()
         sender = Ref{line_sender}()
         port = Ref{UInt16}(port)
         buffer = Ref{line_sender_buffer}()
-        host_utf8 = Ref{line_sender_utf8}()        
+        host_utf8 = Ref{line_sender_utf8}()
         key_id_utf8 = Ref{line_sender_utf8}()
         priv_key_utf8 = Ref{line_sender_utf8}()
         pub_key_x_utf8 = Ref{line_sender_utf8}()
@@ -85,43 +85,54 @@ mutable struct Sender
 
         is_host_ok = line_sender_utf8_init(host_utf8, length(host), host, err)
 
-        global buffer = line_sender_buffer_new();
-        line_sender_buffer_reserve(buffer, 64 * 1024);        
+        buffer[] = line_sender_buffer_new()
+        line_sender_buffer_reserve(buffer[], init_capacity)
 
-        if (is_host_ok)                                    
-            opts = line_sender_opts_new(host_utf8[], port[])                        
-          
-            if (tls)                
-                line_sender_opts_tls(opts);
-            end             
+        if (is_host_ok)
+            opts = line_sender_opts_new(host_utf8[], port[])
+
+            if (tls)
+                line_sender_opts_tls(opts)
+            end
 
             if (auth !== nothing)
                 println("Authenticating...")
                 line_sender_utf8_init(key_id_utf8, length(auth[1]), auth[1], err)
                 line_sender_utf8_init(priv_key_utf8, length(auth[2]), auth[2], err)
                 line_sender_utf8_init(pub_key_x_utf8, length(auth[3]), auth[3], err)
-                line_sender_utf8_init(pub_key_y_utf8, length(auth[4]), auth[4], err)        
-                line_sender_opts_auth(opts, key_id_utf8[], priv_key_utf8[], pub_key_x_utf8[], pub_key_y_utf8[])                                    
-            end        
-            
-            global sender = line_sender_connect(opts, err)                                                    
-            line_sender_opts_free(opts)        
-            
-            if (sender == C_NULL)                        
-                return error_handler(sender, buffer, err);           
-            end            
-        else         
-            error_handler(sender, buffer, err);           
-        end;
-                    
+                line_sender_utf8_init(pub_key_y_utf8, length(auth[4]), auth[4], err)
+                line_sender_opts_auth(opts, key_id_utf8[], priv_key_utf8[], pub_key_x_utf8[], pub_key_y_utf8[])
+            end
+
+            global sender = line_sender_connect(opts, err)
+            line_sender_opts_free(opts)
+
+            if (sender == C_NULL)
+                return error_handler(sender, buffer, err)
+            end
+        else
+            error_handler(sender, buffer, err)
+        end
+
         s = new(host_utf8, port, key_id_utf8, priv_key_utf8, pub_key_x_utf8, pub_key_y_utf8, buffer, opts, err, sender, auth !== nothing)
+
+        # Register finalizer to clean up C resources
+        finalizer(s) do sender_obj
+            if sender_obj.buffer[] != C_NULL
+                line_sender_buffer_free(sender_obj.buffer[])
+            end
+            if sender_obj.sender[] != C_NULL
+                line_sender_close(sender_obj.sender[])
+            end
+        end
+
         return s
     end
 end
 
-function Base.getproperty(s::Sender, f::Base.Symbol)    
-    if f == :table        
-        return Table(s)    
+function Base.getproperty(s::Sender, f::Base.Symbol)
+    if f == :table
+        return Table(s)
     elseif f == :column
         return Column(s)
     elseif f == :symbol
@@ -139,17 +150,17 @@ function Base.getproperty(s::Sender, f::Base.Symbol)
     return getfield(s, f)
 end
 
-function error_handler(sender::Ref{line_sender}, buffer::Ptr{line_sender_buffer}, err::Ref{Ptr{line_sender_error}})                
-    code = line_sender_error_get_code(err[]) 
+function error_handler(sender::Ref{line_sender}, buffer::Ptr{line_sender_buffer}, err::Ref{Ptr{line_sender_error}})
+    code = line_sender_error_get_code(err[])
     len = Ref{Csize_t}(100)
-    message = line_sender_error_msg(err[], len)    
+    message = line_sender_error_msg(err[], len)
     println(unsafe_string(message, len[]))
-    
-    if (code == 0)        
-        error_message = "Error: Could not resolve address, Message: $(unsafe_string(message, len[]))"             
+
+    if (code == 0)
+        error_message = "Error: Could not resolve address, Message: $(unsafe_string(message, len[]))"
     elseif (code == 1)
         error_message = "Invalid API call, Message: $(unsafe_string(message, len[]))"
-    elseif (code == 2)        
+    elseif (code == 2)
         error_message = "Socket error, Message: $(unsafe_string(message, len[]))"
     elseif (code == 3)
         error_message = "Invalid UTF8, Message: $(unsafe_string(message, len[]))"
@@ -163,16 +174,16 @@ function error_handler(sender::Ref{line_sender}, buffer::Ptr{line_sender_buffer}
         error_message = "TLS error, Message: $(unsafe_string(message, len[]))"
     else
         error_message = "Unknown error, Message: $(unsafe_string(message, len[]))"
-    end    
+    end
 
-    line_sender_error_free(err[]);    
-    line_sender_buffer_free(buffer);
-    line_sender_close(sender);
-    throw(ErrorException(error_message))        
+    line_sender_error_free(err[])
+    line_sender_buffer_free(buffer)
+    line_sender_close(sender)
+    throw(ErrorException(error_message))
 end
 
 function capacity(sender::Sender)
-    return line_sender_buffer_capacity(sender.buffer)    
+    return line_sender_buffer_capacity(sender.buffer)
 end
 
 
@@ -191,13 +202,13 @@ end
     sender.table("my_table", ["col1", "col2"], ["int", "string"])
     ```
 """
-function(table::Table)(name::String)
+function (table::Table)(name::String)
     sender = table.sender
-    table_name = line_sender_table_name_assert(length(name), name);                                         
-    line_sender_buffer_table(sender.buffer, table_name, sender.err);                        
-    
+    table_name = line_sender_table_name_assert(length(name), name)
+    line_sender_buffer_table(sender.buffer, table_name, sender.err)
+
     if (sender.err[] != C_NULL)
-        error_handler(sender.sender, sender.buffer, sender.err);           
+        error_handler(sender.sender, sender.buffer, sender.err)
     end
 
     sender
@@ -220,17 +231,17 @@ end
     ## Notes
     * The `column_value` must be a string. 
 """
-function(symbol::Symbol)(name::String, column_value::String)    
+function (symbol::Symbol)(name::String, column_value::String)
     sender = symbol.sender
-    col_name = line_sender_column_name_assert(length(name), name);
-    column_pointer = Ref{line_sender_utf8}();
-    
-    line_sender_utf8_init(column_pointer, length(column_value), column_value, sender.err);                           
-    line_sender_buffer_symbol(sender.buffer, col_name, column_pointer[], sender.err);
+    col_name = line_sender_column_name_assert(length(name), name)
+    column_pointer = Ref{line_sender_utf8}()
+
+    line_sender_utf8_init(column_pointer, length(column_value), column_value, sender.err)
+    line_sender_buffer_symbol(sender.buffer, col_name, column_pointer[], sender.err)
 
     if (sender.err[] != C_NULL)
-        return error_handler(sender.sender, sender.buffer, sender.err);           
-    end    
+        return error_handler(sender.sender, sender.buffer, sender.err)
+    end
     sender
 end
 
@@ -252,30 +263,30 @@ end
     ## Notes
     * The `column_value` must be a string, int64, float64, bool or a date. 
 """
-function(column::Column)(name::String, column_value::Union{String, Int64, Float64, Bool, Dates.Microsecond})
+function (column::Column)(name::String, column_value::Union{String,Int64,Float64,Bool,Dates.Microsecond})
     sender = column.sender
-    col_name = line_sender_column_name_assert(length(name), name);
-    column_pointer = Ref{line_sender_utf8}();        
+    col_name = line_sender_column_name_assert(length(name), name)
+    column_pointer = Ref{line_sender_utf8}()
 
     if column_value isa String
-        line_sender_utf8_init(column_pointer, length(column_value), column_value, sender.err);                           
-        line_sender_buffer_column_str(sender.buffer, col_name, column_pointer[], sender.err);
+        line_sender_utf8_init(column_pointer, length(column_value), column_value, sender.err)
+        line_sender_buffer_column_str(sender.buffer, col_name, column_pointer[], sender.err)
     elseif column_value isa Int64
-        line_sender_buffer_column_i64(sender.buffer, col_name, column_value, sender.err);                                        
+        line_sender_buffer_column_i64(sender.buffer, col_name, column_value, sender.err)
     elseif column_value isa Float64
-        line_sender_buffer_column_f64(sender.buffer, col_name, column_value, sender.err);                                        
+        line_sender_buffer_column_f64(sender.buffer, col_name, column_value, sender.err)
     elseif column_value isa Bool
-        line_sender_buffer_column_bool(sender.buffer, col_name, column_value, sender.err);                                                
+        line_sender_buffer_column_bool(sender.buffer, col_name, column_value, sender.err)
     elseif column_value isa Microsecond
-        ts = convert(Int64, Dates.value(column_value));            
-        line_sender_buffer_column_ts(sender.buffer, col_name, ts, sender.err);                        
+        ts = convert(Int64, Dates.value(column_value))
+        line_sender_buffer_column_ts(sender.buffer, col_name, ts, sender.err)
     else
-        throw("Unsupported type: $(typeof(column_value))");        
-    end;
+        throw("Unsupported type: $(typeof(column_value))")
+    end
 
     if (sender.err[] != C_NULL)
-        return error_handler(sender.sender, sender.buffer, sender.err);
-    end        
+        return error_handler(sender.sender, sender.buffer, sender.err)
+    end
     sender
 end
 
@@ -302,13 +313,13 @@ end
     sender.flush()
     ```
 """
-function(at::At)(ts::Dates.Nanosecond)    
+function (at::At)(ts::Dates.Nanosecond)
     sender = at.sender
-    ts = convert(Int64, Dates.value(ts));        
-    line_sender_buffer_at(sender.buffer, ts, sender.err);       
+    ts = convert(Int64, Dates.value(ts))
+    line_sender_buffer_at(sender.buffer, ts, sender.err)
 
     if (sender.err[] != C_NULL)
-        return error_handler(sender.sender, sender.buffer, sender.err);           
+        return error_handler(sender.sender, sender.buffer, sender.err)
     end
     sender
 end
@@ -330,12 +341,12 @@ end
     sender.flush()
     ```
 """
-function(at_now::AtNow)()    
+function (at_now::AtNow)()
     sender = at_now.sender
-    line_sender_buffer_at_now(sender.buffer, sender.err);       
+    line_sender_buffer_at_now(sender.buffer, sender.err)
 
     if (sender.err[] != C_NULL)
-        return error_handler(sender.sender, sender.buffer, sender.err);           
+        return error_handler(sender.sender, sender.buffer, sender.err)
     end
     sender
 end
@@ -349,23 +360,34 @@ end
     * The buffer is flushed automatically when the `Sender` object is garbage collected.
     * The buffer is flushed automatically when the `Sender` object is closed.
 """
-function(flush::Flush)()
-    println("Flushing...");
+function (flush::Flush)()
+    println("Flushing...")
     sender = flush.sender
-    line_sender_flush(sender.sender, sender.buffer, sender.err);    
-    if sender.err[] != C_NULL          
-        return error_handler(sender.sender, sender.buffer, sender.err);           
-    end;    
+    line_sender_flush(sender.sender, sender.buffer, sender.err)
+    if sender.err[] != C_NULL
+        return error_handler(sender.sender, sender.buffer, sender.err)
+    end
 end
 
 """
     Close the sender object.    
             
 """
-function(close::Close)()
-    println("Closing...");
+function (close::Close)()
+    println("Closing...")
     sender = close.sender
-    line_sender_close(sender.sender);
+
+    # Free buffer if not already freed
+    if sender.buffer[] != C_NULL
+        line_sender_buffer_free(sender.buffer[])
+        sender.buffer[] = C_NULL
+    end
+
+    # Close sender connection
+    if sender.sender[] != C_NULL
+        line_sender_close(sender.sender[])
+        sender.sender[] = C_NULL
+    end
 end
 
 export Sender, capacity

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,12 @@
-using .QuestDB
-using .LibQuestDB
+using QuestDB
 using Dates
-using c_questdb_client_jll
 using Test
 include("mock_server.jl")
 
 # test QuestDB.jl functions
 @testset "Sender testing" begin    
     server = py"Server"()        
-    sender = Sender("localhost", string(server.port))
+    sender = Sender("localhost", server.port)
     server.accept()
     
     # Row 1


### PR DESCRIPTION
PyCall is only used by the tests, so it's more convenient for it to be in the test environment rather than in the package environment. This PR performs the described change and patches the test script accordingly