### PR TITLE
Fix/sender method error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,4 @@ version = "0.1.0"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 c_questdb_client_jll = "49a0df60-3d80-5428-85ce-5c0f24fd7b67"

--- a/src/QuestDB.jl
+++ b/src/QuestDB.jl
@@ -71,7 +71,7 @@ mutable struct Sender
     sender::Ref{line_sender}
     auth::Bool
     
-    function Sender(host::String="localhost", port::Int=9009; auth=nothing, tls::Bool=false)
+    function Sender(host::String="localhost", port::Int=9009; auth=nothing, tls::Bool=false, init_capacity::Int=128*1024)
         err = Ref{Ptr{line_sender_error}}(C_NULL)
         opts = Ref{line_sender_opts}()
         sender = Ref{line_sender}()
@@ -83,7 +83,7 @@ mutable struct Sender
         pub_key_x_utf8 = Ref{line_sender_utf8}()
         pub_key_y_utf8 = Ref{line_sender_utf8}()
 
-        is_host_ok = line_sender_utf8_init(host_utf8, length(host), host, err)    
+        is_host_ok = line_sender_utf8_init(host_utf8, length(host), host, err)
 
         global buffer = line_sender_buffer_new();
         line_sender_buffer_reserve(buffer, 64 * 1024);        
@@ -107,10 +107,10 @@ mutable struct Sender
             global sender = line_sender_connect(opts, err)                                                    
             line_sender_opts_free(opts)        
             
-            if (sender == C_NULL)                                
+            if (sender == C_NULL)                        
                 return error_handler(sender, buffer, err);           
             end            
-        else            
+        else         
             error_handler(sender, buffer, err);           
         end;
                     

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,12 @@
-using .QuestDB
-using .LibQuestDB
+using QuestDB
 using Dates
-using c_questdb_client_jll
 using Test
 include("mock_server.jl")
 
 # test QuestDB.jl functions
 @testset "Sender testing" begin    
     server = py"Server"()        
-    sender = Sender("localhost", string(server.port))
+    sender = Sender("localhost", server.port)
     server.accept()
     
     # Row 1


### PR DESCRIPTION
The API was calling the Sender constructor and passing in the initial_capacity which was erroring out since it wasn't defined in the function.